### PR TITLE
pwmoutput: remove broken code

### DIFF
--- a/pwmoutput.py
+++ b/pwmoutput.py
@@ -3,7 +3,6 @@ import time
 import hal
 from threading import Thread
 from hal_impl.data import hal_data
-from micro_maestro_interface import MotorControl
 
 
 def talon_outputs():
@@ -18,13 +17,11 @@ def talon_outputs():
 class PwmWatch(Thread):
     def __init__(self, output=None):
         Thread.__init__(self)
-        self.MotorControl = MotorControl
         self.output = output
         self.daemon = True
         self.start()
 
     def run(self):
-        MotorControl.set_bounds(0.6, 0.08, 0.0, 0.19, 0.6)
         while True:
             time.sleep(0.05)
             outputs = talon_outputs()


### PR DESCRIPTION
This code should have been committed on a branch and it was accidentally put on master.